### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and error handling especially when using asynchronous methods.
 ### Manual
 
 * Drop `AFHTTPRequestOperation+PromiseKit.h`, `AFHTTPRequestOperation+PromiseKit.m`,
-and `AFNetworking-PromiseKit.h` into an XCode project with AFNetworking
+and `AFNetworking-PromiseKit.h` into an Xcode project with AFNetworking
 and set the appropriate targets.
 
 ## Usage


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
